### PR TITLE
🧹 [code health] Add logging to empty catch blocks in repositories

### DIFF
--- a/lib/data/repository/status_repository.dart
+++ b/lib/data/repository/status_repository.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_storage/firebase_storage.dart';
@@ -160,6 +162,7 @@ class StatusRepository {
           userProfileImage = data?['image'];
         }
       } catch (e) {
+        debugPrint('Error fetching user profile for status: $e');
         // Fallback to defaults
       }
 

--- a/lib/data/repository/user_repository.dart
+++ b/lib/data/repository/user_repository.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:firebase_storage/firebase_storage.dart';
@@ -19,6 +21,7 @@ class UserRepository {
       }
       return null;
     } catch (e) {
+      debugPrint('Error getting user: $e');
       return null;
     }
   }
@@ -44,6 +47,7 @@ class UserRepository {
 
       return snapshot.docs.map((doc) => UserModel.fromDoc(doc)).toList();
     } catch (e) {
+      debugPrint('Error searching users: $e');
       return [];
     }
   }
@@ -65,6 +69,7 @@ class UserRepository {
       await _functions.httpsCallable('updateProfile').call(data);
       return true;
     } catch (e) {
+      debugPrint('Error updating profile: $e');
       return false;
     }
   }
@@ -75,6 +80,7 @@ class UserRepository {
       await ref.putFile(file, SettableMetadata(contentType: 'image/jpeg'));
       return await ref.getDownloadURL();
     } catch (e) {
+      debugPrint('Error uploading profile image: $e');
       return null;
     }
   }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the presence of empty or non-logging catch blocks in `UserRepository` and `StatusRepository`.
💡 **Why:** Adding logging to these catch blocks improves maintainability and debuggability by ensuring that errors are visible in the console instead of being silently swallowed, making it easier to identify and fix issues in production and development.
✅ **Verification:** I manually verified the changes by reading the updated files to confirm that `debugPrint` statements and the necessary imports were correctly added. The changes follow the pattern already established in `ChatRepository`.
✨ **Result:** The codebase now provides context for exceptions in core repository methods, facilitating easier debugging and more robust code health.

---
*PR created automatically by Jules for task [13294878369394801529](https://jules.google.com/task/13294878369394801529) started by @Salint*